### PR TITLE
Add NavAtt [DEVINFRA-878]

### DIFF
--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -1981,10 +1981,30 @@ struct EsfMeas {
 }
 
 #[ubx_packet_recv]
-#[ubx(class = 0x10, id = 0x03, fixed_payload_len = 16)]
-struct EsfRaw {
-    msss: u32,
+#[ubx(class = 0x01, id = 0x05, fixed_payload_len = 32)]
+struct NavAtt {
+    itow: u32,
+    version: u8,
+    reserved1: [u8; 3],
+    #[ubx(map_type = f64, scale = 1e-5, alias = vehicle_roll)]
+    roll: i32,
+    #[ubx(map_type = f64, scale = 1e-5, alias = vehicle_pitch)]
+    pitch: i32,
+    #[ubx(map_type = f64, scale = 1e-5, alias = vehicle_heading)]
+    heading: i32,
+    #[ubx(map_type = f64, scale = 1e-5, alias = vehicle_roll_accuracy)]
+    acc_roll: u32,
+    #[ubx(map_type = f64, scale = 1e-5, alias = vehicle_pitch_accuracy)]
+    acc_pitch: u32,
+    #[ubx(map_type = f64, scale = 1e-5, alias = vehicle_heading_accuracy)]
+    acc_heading: u32,
 }
+
+// #[ubx_packet_recv]
+// #[ubx(class = 0x10, id = 0x03, fixed_payload_len = 16)]
+// struct EsfRaw {
+//     msss: u32,
+// }
 
 define_recv_packets!(
     enum PacketRef {
@@ -2017,5 +2037,6 @@ define_recv_packets!(
         MonHw,
         RxmRtcm,
         EsfMeas,
+        NavAtt,
     }
 );


### PR DESCRIPTION
NavAtt(NavAtt { itow: 329464000, version: 0, reserved1: [0, 0, 0], roll: -1.44974, pitch: -0.6649400000000001, heading: 295.74602000000004, acc_roll: 0.24006000000000002, acc_pitch: 0.27292, acc_heading: 0.1847 })

https://content.u-blox.com/sites/default/files/products/documents/u-blox8-M8_ReceiverDescrProtSpec_UBX-13003221.pdf
p373

Fixed payload lengths as specified in doc